### PR TITLE
chore: Add pypi env to publish routine

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,6 +12,7 @@ jobs:
   publish:
     name: Publish Release
     runs-on: ubuntu-latest
+    environment: pypi
     permissions:
       id-token: write
     steps:


### PR DESCRIPTION
This pull request includes a minor change to the `.github/workflows/publish.yml` file. The change specifies the `environment` as `pypi` for the `publish` job.