### PR TITLE
chore: Bump version to 0.1.2 in __init__.py, pyproject.toml, and uv.lock

### DIFF
--- a/genai_processors_pydantic/__init__.py
+++ b/genai_processors_pydantic/__init__.py
@@ -8,5 +8,5 @@ This is an independent contrib processor for the genai-processors ecosystem.
 
 from .validator import PydanticValidator, ValidationConfig
 
-__version__ = "0.1.1"
+__version__ = "0.1.2"
 __all__ = ["PydanticValidator", "ValidationConfig"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "genai-processors-pydantic"
-version = "0.1.1"
+version = "0.1.2"
 description = "A Pydantic validator processor for Google's genai-processors framework"
 authors = [
     {name = "Mark Beacom", email = "m@beacom.dev"},

--- a/uv.lock
+++ b/uv.lock
@@ -399,7 +399,7 @@ wheels = [
 
 [[package]]
 name = "genai-processors-pydantic"
-version = "0.1.1"
+version = "0.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "genai-processors" },


### PR DESCRIPTION
This pull request updates the package version from `0.1.1` to `0.1.2` to reflect new changes. No other code or functionality changes are included.

* Updated the `__version__` variable in `genai_processors_pydantic/__init__.py` to `0.1.2`.
* Updated the `version` field in `pyproject.toml` to `0.1.2`.